### PR TITLE
feat: revamp templates with one component per each template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 .history
 node_modules
 commit-adjust.sh
-coverage
+coverage 
+dist

--- a/src/components/EditorPage/ResumePreviewStyles.css
+++ b/src/components/EditorPage/ResumePreviewStyles.css
@@ -194,6 +194,11 @@
     white-space: pre-wrap;
 }
 
+/* Single column template content - no sidebar width calculation */
+.content.single-column {
+    width: 100%;
+}
+
 .content h1,
 .content h2,
 .content p,

--- a/src/components/EditorPage/ResumeStyle.vue
+++ b/src/components/EditorPage/ResumeStyle.vue
@@ -16,13 +16,18 @@
                     <div>
                         <div class="text-subtitle-2 mb-3">Choose a template</div>
                         <div class="templates-grid">
-                            <div v-for="template in templateOptions" :key="template.key" class="template-item"
+                            <div v-for="template in templateOptions" :key="template.key"
+                                :class="['template-item', { 'template-item-active': isActiveTemplate(template.key) }]"
                                 @click="confirmTemplateChange(template.key)">
                                 <div class="template-preview">
-                                    <ResumePreview :resume-data="props.resumeData" :style="template.instance"
+                                    <TemplateFactory :resume-data="props.resumeData" :style="template.instance"
                                         :sidebar-position="template.instance.spacing.sidebarLeft ? 'left' : 'right'" />
                                 </div>
-                                <div class="template-name">{{ template.name }}</div>
+                                <div class="template-name">
+                                    {{ template.name }}
+                                    <v-icon v-if="isActiveTemplate(template.key)" icon="ph-check-circle" size="small"
+                                        color="primary" class="ml-2" />
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -167,12 +172,12 @@
                         <div class="text-subtitle-2">Content Spacing</div>
                         <v-slider v-model="styleData.spacing.content" min="0" max="24" step="2" thumb-label></v-slider>
                     </div>
-                    <div class="slider-container">
+                    <div class="slider-container" v-if="!isOneColumnTemplate">
                         <div class="text-subtitle-2">Sidebar Width</div>
                         <v-slider v-model="styleData.spacing.sidebarWidth" min="0" max="400" step="10"
                             thumb-label></v-slider>
                     </div>
-                    <div>
+                    <div v-if="!isOneColumnTemplate">
                         <v-switch v-model="styleData.spacing.sidebarLeft" :disabled="!isSidebarPresent"
                             label="Sidebar on Left" hide-details density="compact" color="primary"></v-switch>
                     </div>
@@ -220,7 +225,7 @@
 <script setup>
 import { ResumeStyleV1_1 } from '@/models/ResumeStyle/ResumeStyleV1_1'
 import { TemplateService } from '@/services/TemplateService'
-import ResumePreview from './ResumePreview.vue'
+import TemplateFactory from './templates/TemplateFactory.vue'
 import { computed, ref } from 'vue'
 
 const props = defineProps({
@@ -251,6 +256,10 @@ const onTemplateSelect = (templateKey) => {
 
     const templateInstance = TemplateService.createTemplateInstance(templateKey)
     if (templateInstance) {
+        // Completely replace the style data instead of merging
+        Object.keys(props.styleData).forEach(key => {
+            delete props.styleData[key]
+        })
         Object.assign(props.styleData, templateInstance)
         props.styleData.templateName = templateInstance.templateName
         emit('update:style-data', props.styleData)
@@ -291,6 +300,14 @@ const validateHex = (key) => {
 const isSidebarPresent = computed(() => {
     return props.styleData.spacing.sidebarWidth > 0
 })
+
+const isOneColumnTemplate = computed(() => {
+    return props.styleData.templateName === 'OneColumnModern'
+})
+
+const isActiveTemplate = (templateKey) => {
+    return props.styleData.templateName === templateKey
+}
 
 const templatesExpanded = ref(false)
 const toggleTemplates = () => {
@@ -526,6 +543,17 @@ const handleCustomCSSChange = () => {
     border-color: rgb(var(--v-theme-primary));
     transform: translateY(-2px);
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.template-item-active {
+    border-color: rgb(var(--v-theme-primary)) !important;
+    background-color: rgba(var(--v-theme-primary), 0.05) !important;
+    box-shadow: 0 4px 12px rgba(var(--v-theme-primary), 0.2) !important;
+}
+
+.template-item-active:hover {
+    border-color: rgb(var(--v-theme-primary)) !important;
+    background-color: rgba(var(--v-theme-primary), 0.08) !important;
 }
 
 .template-preview {

--- a/src/components/EditorPage/__tests__/ResumePreviewContent.test.js
+++ b/src/components/EditorPage/__tests__/ResumePreviewContent.test.js
@@ -1,10 +1,10 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { mount } from '@vue/test-utils'
-import ResumePreview from '@/components/EditorPage/ResumePreview.vue'
+import TemplateFactory from '@/components/EditorPage/templates/TemplateFactory.vue'
 import { vuetify } from '@/test/setup'
 import { ResumeDataV2 } from '@/models/ResumeData/ResumeDataV2'
 
-describe('ResumePreview Content', () => {
+describe('TemplateFactory Content', () => {
     let wrapper
 
     const mockResumeData = new ResumeDataV2({
@@ -102,7 +102,7 @@ describe('ResumePreview Content', () => {
     }
 
     beforeEach(() => {
-        wrapper = mount(ResumePreview, {
+        wrapper = mount(TemplateFactory, {
             global: {
                 plugins: [vuetify]
             },

--- a/src/components/EditorPage/__tests__/ResumePreviewStyle.test.js
+++ b/src/components/EditorPage/__tests__/ResumePreviewStyle.test.js
@@ -1,9 +1,9 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { mount } from '@vue/test-utils'
-import ResumePreview from '@/components/EditorPage/ResumePreview.vue'
+import TemplateFactory from '@/components/EditorPage/templates/TemplateFactory.vue'
 import { vuetify } from '@/test/setup'
 
-describe('ResumePreview Style', () => {
+describe('TemplateFactory Style', () => {
     let wrapper
 
     const mockResumeData = {
@@ -41,7 +41,7 @@ describe('ResumePreview Style', () => {
     }
 
     beforeEach(() => {
-        wrapper = mount(ResumePreview, {
+        wrapper = mount(TemplateFactory, {
             global: {
                 plugins: [vuetify]
             },
@@ -289,6 +289,7 @@ describe('ResumePreview Style', () => {
         it('correctly computes isSidebarPresent when sidebar width is 0', async () => {
             const styleWithZeroSidebar = {
                 ...mockStyle,
+                templateName: 'TwoColumnsBlue',
                 spacing: {
                     ...mockStyle.spacing,
                     sidebarWidth: 0
@@ -297,7 +298,9 @@ describe('ResumePreview Style', () => {
 
             await wrapper.setProps({ style: styleWithZeroSidebar })
 
-            expect(wrapper.vm.isSidebarPresent).toBe(false)
+            // Access computed properties through the template component
+            const templateComponent = wrapper.findComponent({ name: 'TwoColumnTemplate' })
+            expect(templateComponent.vm.isSidebarPresent).toBe(false)
         })
 
         it('correctly computes isSidebarPresent when sidebar width is greater than 0', async () => {
@@ -311,7 +314,9 @@ describe('ResumePreview Style', () => {
 
             await wrapper.setProps({ style: styleWithSidebar })
 
-            expect(wrapper.vm.isSidebarPresent).toBe(true)
+            // Access computed properties through the template component
+            const templateComponent = wrapper.findComponent({ name: 'TwoColumnTemplate' })
+            expect(templateComponent.vm.isSidebarPresent).toBe(true)
         })
 
         it('correctly filters sidebar custom sections', async () => {
@@ -346,8 +351,10 @@ describe('ResumePreview Style', () => {
                 style: styleWithSidebar
             })
 
-            expect(wrapper.vm.sidebarCustomSections).toHaveLength(1)
-            expect(wrapper.vm.sidebarCustomSections[0].title).toBe('Skills')
+            // Access computed properties through the template component
+            const templateComponent = wrapper.findComponent({ name: 'TwoColumnTemplate' })
+            expect(templateComponent.vm.sidebarCustomSections).toHaveLength(1)
+            expect(templateComponent.vm.sidebarCustomSections[0].title).toBe('Skills')
         })
 
         it('moves all sections to main content when sidebar is not present', async () => {
@@ -371,6 +378,7 @@ describe('ResumePreview Style', () => {
 
             const styleWithZeroSidebar = {
                 ...mockStyle,
+                templateName: 'TwoColumnsBlue',
                 spacing: {
                     ...mockStyle.spacing,
                     sidebarWidth: 0
@@ -382,7 +390,9 @@ describe('ResumePreview Style', () => {
                 style: styleWithZeroSidebar
             })
 
-            expect(wrapper.vm.mainCustomSections).toHaveLength(2)
+            // Access computed properties through the template component
+            const templateComponent = wrapper.findComponent({ name: 'TwoColumnTemplate' })
+            expect(templateComponent.vm.mainCustomSections).toHaveLength(2)
         })
     })
 

--- a/src/components/EditorPage/templates/BaseTemplate.vue
+++ b/src/components/EditorPage/templates/BaseTemplate.vue
@@ -66,6 +66,10 @@ export default {
   beforeUnmount() {
     this.removeCustomCSS()
   },
+  unmounted() {
+    // Ensure cleanup happens even if beforeUnmount doesn't trigger
+    this.removeCustomCSS()
+  },
   watch: {
     'style.customCSS': {
       handler() {

--- a/src/components/EditorPage/templates/BaseTemplate.vue
+++ b/src/components/EditorPage/templates/BaseTemplate.vue
@@ -1,62 +1,15 @@
 <template>
   <div id="printable-area">
     <div class="resume-preview" :style="resumeStyle">
-      <div class="preview-container">
-        <div class="container" :class="{ 'sidebar-left': sidebarPosition === 'left' }">
-
-          <div class="sidebar" v-if="isSidebarPresent">
-            <template v-for="(section, index) in sidebarCustomSections" :key="index">
-              <h2>{{ section.title }}</h2>
-              <div v-html="processContent(section.content)"></div>
-            </template>
-          </div>
-
-          <div class="content">
-            <h1>{{ resumeData.personal.name || 'Your Name' }}</h1>
-            <h2 class="subtitle">{{ resumeData.personal.title }}</h2>
-
-            <div class="section"
-              v-if="resumeData.experiencesVisible && resumeData.experiences && resumeData.experiences.filter(e => e?.visible).length">
-              <h2>{{ resumeData.experiencesSectionName }}</h2>
-              <div v-for="(e, i) in resumeData.experiences" :key="i">
-                <template v-if="e?.visible">
-                  <p class="job-title">{{ e.title }} - {{ e.company }}</p>
-                  <p class="date">{{ e.period }}</p>
-                  <p class="job-desc" v-html="processContent(e.description)"></p>
-                </template>
-              </div>
-            </div>
-
-            <div class="section"
-              v-if="resumeData.educationVisible && resumeData.education && resumeData.education.filter(e => e?.visible).length">
-              <h2>{{ resumeData.educationSectionName }}</h2>
-              <div v-for="(ed, i) in resumeData.education" :key="i">
-                <template v-if="ed?.visible">
-                  <p class="job-title">{{ ed.degree }} - {{ ed.school }}</p>
-                  <div>
-                    <p class="date">{{ ed.period }}</p>
-                    <p class="graduation-mark">{{ ed.mark }}</p>
-                  </div>
-                  <p class="thesis" v-html="processContent(ed.thesis)"></p>
-                </template>
-              </div>
-            </div>
-
-            <template v-for="(section, index) in mainCustomSections" :key="index">
-              <div class="section">
-                <h2>{{ section.title }}</h2>
-                <div v-html="processContent(section.content)"></div>
-              </div>
-            </template>
-          </div>
-        </div>
-      </div>
+      <!-- Template-specific content will be overridden -->
+      <slot />
     </div>
   </div>
 </template>
 
 <script>
 export default {
+  name: 'BaseTemplate',
   props: {
     resumeData: {
       type: Object,
@@ -89,6 +42,7 @@ export default {
     },
     updateCustomCSS() {
       this.removeCustomCSS()
+      // Only inject if there's actual CSS content
       if (this.style.customCSS && this.style.customCSS.trim()) {
         const styleElement = document.createElement('style')
         styleElement.id = 'resume-custom-css'
@@ -101,6 +55,9 @@ export default {
       if (existingStyle) {
         existingStyle.remove()
       }
+      // Also remove any other potential custom CSS elements
+      const allCustomStyles = document.querySelectorAll('style[id^="resume-custom"]')
+      allCustomStyles.forEach(style => style.remove())
     }
   },
   mounted() {
@@ -114,6 +71,25 @@ export default {
       handler() {
         this.updateCustomCSS()
       },
+      immediate: true
+    },
+    'style.templateName': {
+      handler() {
+        // Force CSS update when template changes
+        this.$nextTick(() => {
+          this.updateCustomCSS()
+        })
+      },
+      immediate: true
+    },
+    // Watch for any changes to the entire style object
+    style: {
+      handler() {
+        this.$nextTick(() => {
+          this.updateCustomCSS()
+        })
+      },
+      deep: true,
       immediate: true
     }
   },
@@ -138,25 +114,13 @@ export default {
         '--sidebar-width': `${spacing.sidebarWidth}px`
       }
 
-      // Custom CSS is handled in mounted hook and watchers
-
       return baseStyles
     },
     visibleCustomSections() {
       return this.resumeData.customSections.filter(s => s && s.visible !== false)
-    },
-    isSidebarPresent() {
-      return this.style.spacing.sidebarWidth > 0
-    },
-    sidebarCustomSections() {
-      return this.visibleCustomSections.filter(s => s.position === 'sidebar')
-    },
-    mainCustomSections() {
-      // If sidebar is not present, show all custom sections in main content
-      return this.visibleCustomSections.filter(s => s.position === 'main' || !this.isSidebarPresent)
     }
   }
 }
 </script>
 
-<style src="./ResumePreviewStyles.css"></style>
+<style src="../ResumePreviewStyles.css"></style> 

--- a/src/components/EditorPage/templates/OneColumnModern.vue
+++ b/src/components/EditorPage/templates/OneColumnModern.vue
@@ -1,0 +1,84 @@
+<template>
+  <BaseTemplate v-bind="$props">
+    <div class="preview-container">
+      <div class="container single-column">
+        <div class="content single-column centered">
+          <h1>{{ resumeData.personal.name || 'Your Name' }}</h1>
+          <h2 class="subtitle">{{ resumeData.personal.title }}</h2>
+
+          <div class="section"
+            v-if="resumeData.experiencesVisible && resumeData.experiences && resumeData.experiences.filter(e => e?.visible).length">
+            <h2>{{ resumeData.experiencesSectionName }}</h2>
+            <div v-for="(e, i) in resumeData.experiences" :key="i">
+              <template v-if="e?.visible">
+                <p class="job-title">{{ e.title }} - {{ e.company }}</p>
+                <p class="date">{{ e.period }}</p>
+                <p class="job-desc" v-html="processContent(e.description)"></p>
+              </template>
+            </div>
+          </div>
+
+          <div class="section"
+            v-if="resumeData.educationVisible && resumeData.education && resumeData.education.filter(e => e?.visible).length">
+            <h2>{{ resumeData.educationSectionName }}</h2>
+            <div v-for="(ed, i) in resumeData.education" :key="i">
+              <template v-if="ed?.visible">
+                <p class="job-title">{{ ed.degree }} - {{ ed.school }}</p>
+                <div>
+                  <p class="date">{{ ed.period }}</p>
+                  <p class="graduation-mark">{{ ed.mark }}</p>
+                </div>
+                <p class="thesis" v-html="processContent(ed.thesis)"></p>
+              </template>
+            </div>
+          </div>
+
+          <template v-for="(section, index) in allCustomSections" :key="index">
+            <div class="section">
+              <h2>{{ section.title }}</h2>
+              <div v-html="processContent(section.content)"></div>
+            </div>
+          </template>
+        </div>
+      </div>
+    </div>
+  </BaseTemplate>
+</template>
+
+<script>
+import BaseTemplate from './BaseTemplate.vue'
+
+export default {
+  name: 'OneColumnModern',
+  components: { BaseTemplate },
+  extends: BaseTemplate,
+  computed: {
+    // For OneColumnModern, show all custom sections in main content
+    allCustomSections() {
+      return this.visibleCustomSections
+    }
+  }
+}
+</script>
+
+<style scoped>
+.single-column {
+  flex-direction: column !important;
+}
+
+.centered {
+  text-align: center;
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 32px 48px 64px;
+}
+
+.centered h1,
+.centered .subtitle {
+  text-align: center;
+}
+
+.centered .section {
+  text-align: left;
+}
+</style> 

--- a/src/components/EditorPage/templates/TemplateFactory.vue
+++ b/src/components/EditorPage/templates/TemplateFactory.vue
@@ -48,6 +48,14 @@ export default {
       const templateName = this.style.templateName || 'TwoColumnsBlue'
       return TEMPLATE_COMPONENTS[templateName] || TwoColumnTemplate
     }
+  },
+  beforeUnmount() {
+    // Ensure child components are properly unmounted
+    this.$nextTick(() => {
+      // Force cleanup of any remaining custom CSS
+      const remainingStyles = document.querySelectorAll('style[id^="resume-custom"]')
+      remainingStyles.forEach(style => style.remove())
+    })
   }
 }
 </script> 

--- a/src/components/EditorPage/templates/TemplateFactory.vue
+++ b/src/components/EditorPage/templates/TemplateFactory.vue
@@ -1,0 +1,53 @@
+<template>
+  <component 
+    :is="templateComponent" 
+    v-bind="$props"
+    @update="$emit('update', $event)"
+  />
+</template>
+
+<script>
+import BaseTemplate from './BaseTemplate.vue'
+import TwoColumnTemplate from './TwoColumnTemplate.vue'
+import OneColumnModern from './OneColumnModern.vue'
+
+const TEMPLATE_COMPONENTS = {
+  'TwoColumnsBlue': TwoColumnTemplate,
+  'TwoColumnsGreen': TwoColumnTemplate,
+  'OneColumnModern': OneColumnModern
+}
+
+export default {
+  name: 'TemplateFactory',
+  components: {
+    BaseTemplate
+  },
+  props: {
+    resumeData: {
+      type: Object,
+      required: true
+    },
+    style: {
+      type: Object,
+      required: true
+    },
+    downloadId: {
+      type: String,
+      default: ''
+    },
+    sidebarPosition: {
+      type: String,
+      default: 'right',
+      validator: (value) => ['left', 'right'].includes(value)
+    }
+  },
+  emits: ['update'],
+  computed: {
+    templateComponent() {
+      // Use explicit templateName if available, otherwise default to TwoColumnsBlue
+      const templateName = this.style.templateName || 'TwoColumnsBlue'
+      return TEMPLATE_COMPONENTS[templateName] || TwoColumnTemplate
+    }
+  }
+}
+</script> 

--- a/src/components/EditorPage/templates/TwoColumnTemplate.vue
+++ b/src/components/EditorPage/templates/TwoColumnTemplate.vue
@@ -1,0 +1,76 @@
+<template>
+  <BaseTemplate v-bind="$props">
+    <div class="preview-container">
+      <div class="container" :class="{ 'sidebar-left': sidebarPosition === 'left' }">
+        <div class="sidebar" v-if="isSidebarPresent">
+          <template v-for="(section, index) in sidebarCustomSections" :key="index">
+            <h2>{{ section.title }}</h2>
+            <div v-html="processContent(section.content)"></div>
+          </template>
+        </div>
+
+        <div class="content">
+          <h1>{{ resumeData.personal.name || 'Your Name' }}</h1>
+          <h2 class="subtitle">{{ resumeData.personal.title }}</h2>
+
+          <div class="section"
+            v-if="resumeData.experiencesVisible && resumeData.experiences && resumeData.experiences.filter(e => e?.visible).length">
+            <h2>{{ resumeData.experiencesSectionName }}</h2>
+            <div v-for="(e, i) in resumeData.experiences" :key="i">
+              <template v-if="e?.visible">
+                <p class="job-title">{{ e.title }} - {{ e.company }}</p>
+                <p class="date">{{ e.period }}</p>
+                <p class="job-desc" v-html="processContent(e.description)"></p>
+              </template>
+            </div>
+          </div>
+
+          <div class="section"
+            v-if="resumeData.educationVisible && resumeData.education && resumeData.education.filter(e => e?.visible).length">
+            <h2>{{ resumeData.educationSectionName }}</h2>
+            <div v-for="(ed, i) in resumeData.education" :key="i">
+              <template v-if="ed?.visible">
+                <p class="job-title">{{ ed.degree }} - {{ ed.school }}</p>
+                <div>
+                  <p class="date">{{ ed.period }}</p>
+                  <p class="graduation-mark">{{ ed.mark }}</p>
+                </div>
+                <p class="thesis" v-html="processContent(ed.thesis)"></p>
+              </template>
+            </div>
+          </div>
+
+          <template v-for="(section, index) in mainCustomSections" :key="index">
+            <div class="section">
+              <h2>{{ section.title }}</h2>
+              <div v-html="processContent(section.content)"></div>
+            </div>
+          </template>
+        </div>
+      </div>
+    </div>
+  </BaseTemplate>
+</template>
+
+<script>
+import BaseTemplate from './BaseTemplate.vue'
+
+export default {
+  name: 'TwoColumnTemplate',
+  components: { BaseTemplate },
+  extends: BaseTemplate,
+  computed: {
+    // Sidebar-related computed properties for two-column templates
+    isSidebarPresent() {
+      return this.style.spacing.sidebarWidth > 0
+    },
+    sidebarCustomSections() {
+      return this.visibleCustomSections.filter(s => s.position === 'sidebar')
+    },
+    mainCustomSections() {
+      // If sidebar is not present, show all custom sections in main content
+      return this.visibleCustomSections.filter(s => s.position === 'main' || !this.isSidebarPresent)
+    }
+  }
+}
+</script> 

--- a/src/components/EditorPage/templates/__tests__/TemplateFactory.test.js
+++ b/src/components/EditorPage/templates/__tests__/TemplateFactory.test.js
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import TemplateFactory from '../TemplateFactory.vue'
+import { vuetify } from '@/test/setup'
+
+describe('TemplateFactory', () => {
+    let wrapper
+
+    const mockResumeData = {
+        personal: {
+            name: 'John Doe',
+            title: 'Software Engineer',
+            visible: true
+        },
+        experiences: [],
+        experiencesVisible: true,
+        education: [],
+        educationVisible: true,
+        customSections: []
+    }
+
+    const mockStyle = {
+        colors: {
+            primary: '#1976D2',
+            text: '#000000',
+            background: '#ffffff',
+            sidebar: '#1976D2',
+            link: '#1976D2'
+        },
+        typography: {
+            headingFont: 'Arial',
+            bodyFont: 'Arial',
+            baseSize: 12,
+            headingSize: 16
+        },
+        spacing: {
+            section: 16,
+            content: 8,
+            sidebarWidth: 280
+        }
+    }
+
+    beforeEach(() => {
+        wrapper = mount(TemplateFactory, {
+            global: {
+                plugins: [vuetify]
+            },
+            props: {
+                resumeData: mockResumeData,
+                style: mockStyle,
+                sidebarPosition: 'right'
+            }
+        })
+    })
+
+    describe('Template Selection', () => {
+        it('loads TwoColumnTemplate for TwoColumnsBlue template', () => {
+            const styleWithTemplate = {
+                ...mockStyle,
+                templateName: 'TwoColumnsBlue'
+            }
+            
+            wrapper = mount(TemplateFactory, {
+                global: {
+                    plugins: [vuetify]
+                },
+                props: {
+                    resumeData: mockResumeData,
+                    style: styleWithTemplate,
+                    sidebarPosition: 'right'
+                }
+            })
+
+            expect(wrapper.vm.templateComponent.name).toBe('TwoColumnTemplate')
+        })
+
+        it('loads TwoColumnTemplate for TwoColumnsGreen template', () => {
+            const styleWithTemplate = {
+                ...mockStyle,
+                templateName: 'TwoColumnsGreen'
+            }
+            
+            wrapper = mount(TemplateFactory, {
+                global: {
+                    plugins: [vuetify]
+                },
+                props: {
+                    resumeData: mockResumeData,
+                    style: styleWithTemplate,
+                    sidebarPosition: 'right'
+                }
+            })
+
+            expect(wrapper.vm.templateComponent.name).toBe('TwoColumnTemplate')
+        })
+
+        it('loads OneColumnModern for OneColumnModern template', () => {
+            const styleWithTemplate = {
+                ...mockStyle,
+                templateName: 'OneColumnModern'
+            }
+            
+            wrapper = mount(TemplateFactory, {
+                global: {
+                    plugins: [vuetify]
+                },
+                props: {
+                    resumeData: mockResumeData,
+                    style: styleWithTemplate,
+                    sidebarPosition: 'right'
+                }
+            })
+
+            expect(wrapper.vm.templateComponent.name).toBe('OneColumnModern')
+        })
+
+        it('defaults to TwoColumnsBlue when no template name is specified', () => {
+            expect(wrapper.vm.templateComponent.name).toBe('TwoColumnTemplate')
+        })
+
+        it('falls back to TwoColumnTemplate for unknown template', () => {
+            const styleWithUnknownTemplate = {
+                ...mockStyle,
+                templateName: 'UnknownTemplate'
+            }
+            
+            wrapper = mount(TemplateFactory, {
+                global: {
+                    plugins: [vuetify]
+                },
+                props: {
+                    resumeData: mockResumeData,
+                    style: styleWithUnknownTemplate,
+                    sidebarPosition: 'right'
+                }
+            })
+
+            expect(wrapper.vm.templateComponent.name).toBe('TwoColumnTemplate')
+        })
+    })
+
+    describe('Props Passing', () => {
+        it('passes all props to the selected template component', () => {
+            const styleWithTemplate = {
+                ...mockStyle,
+                templateName: 'TwoColumnsBlue'
+            }
+            
+            wrapper = mount(TemplateFactory, {
+                global: {
+                    plugins: [vuetify]
+                },
+                props: {
+                    resumeData: mockResumeData,
+                    style: styleWithTemplate,
+                    downloadId: 'test-id',
+                    sidebarPosition: 'left'
+                }
+            })
+
+            const templateComponent = wrapper.findComponent({ name: 'TwoColumnTemplate' })
+            expect(templateComponent.exists()).toBe(true)
+            expect(templateComponent.props('resumeData')).toEqual(mockResumeData)
+            expect(templateComponent.props('style')).toEqual(styleWithTemplate)
+            expect(templateComponent.props('downloadId')).toBe('test-id')
+            expect(templateComponent.props('sidebarPosition')).toBe('left')
+        })
+    })
+}) 

--- a/src/models/ResumeStyle/ResumeStyleV1_1.js
+++ b/src/models/ResumeStyle/ResumeStyleV1_1.js
@@ -44,6 +44,7 @@ export class ResumeStyleV1_1 {
 
     static createDefault() {
         return {
+            templateName: 'TwoColumnsBlue',
             colors: {
                 primary: '#08294D',
                 text: '#08294D',

--- a/src/models/ResumeStyle/defaultTemplates/OneColumnModern.js
+++ b/src/models/ResumeStyle/defaultTemplates/OneColumnModern.js
@@ -5,6 +5,7 @@ export class OneColumnModern extends ResumeStyleV1_1 {
 
     static createDefault() {
         return {
+            templateName: 'OneColumnModern',
             colors: {
                 primary: '#2C3E50',
                 text: '#2C3E50',
@@ -31,7 +32,7 @@ export class OneColumnModern extends ResumeStyleV1_1 {
                 left: ['personal', 'education', 'experiences', 'customSections'],
                 right: []
             },
-            customCSS: `h1, .subtitle {text-align: center}`                
+            customCSS: `h1, .subtitle {text-align: center}`
         };
     }
 

--- a/src/models/ResumeStyle/defaultTemplates/TwoColumnsBlue.js
+++ b/src/models/ResumeStyle/defaultTemplates/TwoColumnsBlue.js
@@ -5,6 +5,7 @@ export class TwoColumnsBlue extends ResumeStyleV1_1 {
 
     static createDefault() {
         return {
+            templateName: 'TwoColumnsBlue',
             colors: {
                 primary: '#08294D',
                 text: '#08294D',

--- a/src/models/ResumeStyle/defaultTemplates/TwoColumnsGreen.js
+++ b/src/models/ResumeStyle/defaultTemplates/TwoColumnsGreen.js
@@ -5,6 +5,7 @@ export class TwoColumnsGreen extends ResumeStyleV1_1 {
 
     static createDefault() {
         return {
+            templateName: 'TwoColumnsGreen',
             colors: {
                 primary: '#27AE60',
                 text: '#2C3E50',

--- a/src/views/EditorPage.vue
+++ b/src/views/EditorPage.vue
@@ -20,7 +20,7 @@
                 <div class="preview-col" :class="{ 'hidden': isMobile }" :style="!isMobile ? { width: '65%' } : {}">
                     <div class="preview-container"
                         :style="{ transform: `scale(${zoomLevel / 100})`, transformOrigin: 'top center' }">
-                        <ResumePreview :resume-data="resumeData" :style="resumeStyle"
+                        <TemplateFactory :resume-data="resumeData" :style="resumeStyle"
                             :sidebar-position="resumeStyle.spacing.sidebarLeft ? 'left' : 'right'" />
                     </div>
                 </div>
@@ -43,7 +43,7 @@
 import LateralMenu from '@/components/EditorPage/LateralMenu.vue'
 import ConvertCVDialog from '@/components/EditorPage/ConvertCVDialog.vue'
 import ResumeEditor from '@/components/EditorPage/ResumeEditor.vue'
-import ResumePreview from '@/components/EditorPage/ResumePreview.vue'
+import TemplateFactory from '@/components/EditorPage/templates/TemplateFactory.vue'
 import { CVConversionService } from '@/services/CVConversionService'
 import { ExporterService } from '@/services/ExporterService'
 import { ResumeDataClass, ResumeService, ResumeStyleClass } from '@/services/ResumeService'

--- a/src/views/__tests__/EditorPage.test.js
+++ b/src/views/__tests__/EditorPage.test.js
@@ -30,10 +30,10 @@ vi.mock('@/components/EditorPage/ResumeEditor.vue', () => ({
     }
 }))
 
-vi.mock('@/components/EditorPage/ResumePreview.vue', () => ({
+vi.mock('@/components/EditorPage/templates/TemplateFactory.vue', () => ({
     default: {
-        name: 'ResumePreview',
-        template: '<div class="resume-preview-mock">ResumePreview Mock</div>',
+        name: 'TemplateFactory',
+        template: '<div class="template-factory-mock">TemplateFactory Mock</div>',
         props: ['resumeData', 'style', 'sidebarPosition']
     }
 }))
@@ -138,8 +138,8 @@ describe('EditorPage', () => {
                         props: ['resumeData', 'style', 'activeTab', 'isMobile'],
                         emits: ['update:resume-data', 'update:style', 'update:activeTab', 'save', 'change']
                     },
-                    'ResumePreview': {
-                        template: '<div class="resume-preview-mock">ResumePreview Mock</div>',
+                    'TemplateFactory': {
+                        template: '<div class="template-factory-mock">TemplateFactory Mock</div>',
                         props: ['resumeData', 'style', 'sidebarPosition']
                     },
                     'ConvertCVDialog': {
@@ -706,7 +706,7 @@ describe('EditorPage', () => {
             // Check that all child components are rendered
             expect(wrapper.findComponent({ name: 'LateralMenu' })).toBeTruthy()
             expect(wrapper.findComponent({ name: 'ResumeEditor' })).toBeTruthy()
-            expect(wrapper.findComponent({ name: 'ResumePreview' })).toBeTruthy()
+            expect(wrapper.findComponent({ name: 'TemplateFactory' })).toBeTruthy()
             expect(wrapper.findComponent({ name: 'ConvertCVDialog' })).toBeTruthy()
         })
     })


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Reworked the resume template system so each template is now a separate component, making it easier to add and maintain templates.

- **New Features**
  - Added `TemplateFactory` to select and render the correct template component.
  - Created dedicated components for `OneColumnModern` and `TwoColumnTemplate`.
  - Updated tests and styles to support the new structure.

<!-- End of auto-generated description by cubic. -->

