### PR TITLE
feat: add guides for page break

### DIFF
--- a/src/components/EditorPage/ResumePreviewStyles.css
+++ b/src/components/EditorPage/ResumePreviewStyles.css
@@ -10,6 +10,7 @@
     @page {
         size: A4;
         margin: 0;
+        break-inside: auto; /* default: allow breaks inside */
     }
 
     html,

--- a/src/components/EditorPage/templates/OneColumnModern.vue
+++ b/src/components/EditorPage/templates/OneColumnModern.vue
@@ -183,18 +183,4 @@ export default {
 .ocm-resume * {
   white-space: normal;
 }
-
-@media print {
-  .ocm-resume {
-    margin: 0;
-    padding: 15mm;
-    border: none;
-    box-shadow: none;
-    width: 100%;
-    max-width: 100%;
-    box-sizing: border-box;
-    -webkit-print-color-adjust: exact;
-    print-color-adjust: exact;
-  }
-}
 </style>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds dashed page break guides to the resume preview so users can see where A4 pages will split. Also consolidates print styling into shared CSS.

- New Features
  - Overlay dashed lines at A4 intervals with a small “Page will be cut approximately here” label.
  - Guides update on content and size changes via ResizeObserver and respect zoom.
  - Preview-only; not included in print/PDF export.

- Refactors
  - Removed template-specific print styles in OneColumnModern to use shared ResumePreviewStyles.css.
  - Set @page defaults (A4, zero margin, break-inside: auto).

<!-- End of auto-generated description by cubic. -->

